### PR TITLE
Improve consumer

### DIFF
--- a/danube-broker/src/broker_server/consumer_handler.rs
+++ b/danube-broker/src/broker_server/consumer_handler.rs
@@ -102,18 +102,16 @@ impl ConsumerService for DanubeServerImpl {
         &self,
         request: tonic::Request<ReceiveRequest>,
     ) -> std::result::Result<tonic::Response<Self::ReceiveMessagesStream>, tonic::Status> {
-        let (tx, rx) = mpsc::channel(4); // Buffer size of 4, adjust as needed
-        let (tx_consumer, mut rx_consumer) = mpsc::channel(4);
         let consumer_id = request.into_inner().consumer_id;
 
-        info!(
-            "The Consumer with id: {} requested to receive messages",
-            consumer_id
-        );
+        // Create a new mpsc channel to stream messages to the client via gRPC
+        let (grpc_tx, grpc_rx) = mpsc::channel(4); // Buffer size of 4, adjust as needed
 
-        let service = self.service.lock().await;
+        info!("Consumer {} is ready to receive messages", consumer_id);
 
-        let consumer = if let Some(consumer) = service.find_consumer_by_id(consumer_id).await {
+        let mut service = self.service.lock().await;
+
+        let rx = if let Some(consumer) = service.find_consumer_rx(consumer_id).await {
             consumer
         } else {
             let status = Status::not_found(format!(
@@ -123,41 +121,23 @@ impl ConsumerService for DanubeServerImpl {
             return Err(status);
         };
 
-        // sends the channel's tx to consumer
-        consumer.lock().await.set_tx(tx_consumer);
+        let mut rx_guard = rx.lock().await;
 
-        //for each consumer spawn a task to send messages
-        tokio::spawn(async move {
-            while let Some(messages) = rx_consumer.recv().await {
-                // TODO! should I respond with request id ??
-                let request_id = 1;
+        while let Some(message) = rx_guard.recv().await {
+            let stream_message = StreamMessage {
+                request_id: 1, // Placeholder; ideally, map this to a proper request ID
+                payload: message.payload,
+                metadata: message.metadata,
+            };
 
-                let stream_messages = StreamMessage {
-                    request_id: request_id,
-                    payload: messages.payload,
-                    metadata: messages.metadata,
-                };
-
-                if tx.send(Ok(stream_messages)).await.is_err() {
-                    // Consumer is disconnected or error occurred while sending.
-                    break;
-                }
-
-                trace!(
-                    "The message with request_id: {} was sent to consumer {}",
-                    request_id,
-                    consumer_id
-                );
+            if grpc_tx.send(Ok(stream_message)).await.is_err() {
+                // Error handling for when the client disconnects
+                warn!("Client disconnected for consumer_id: {}", consumer_id);
+                break;
             }
+        }
 
-            // Exit the loop if rx_consumer is closed or if tx fails to send.
-            warn!(
-                "Consumer {} has disconnected or a message send failure occurred.",
-                consumer_id
-            );
-        });
-
-        Ok(Response::new(ReceiverStream::new(rx)))
+        Ok(Response::new(ReceiverStream::new(grpc_rx)))
     }
 
     // Consumer acknowledge the received message

--- a/danube-broker/src/consumer.rs
+++ b/danube-broker/src/consumer.rs
@@ -6,19 +6,20 @@ use tracing::{info, trace, warn};
 
 use crate::{
     broker_metrics::{CONSUMER_BYTES_OUT_COUNTER, CONSUMER_MSG_OUT_COUNTER, TOPIC_CONSUMERS},
-    proto::{MessageMetadata, StreamMessage},
+    proto::MessageMetadata,
 };
 
 /// Represents a consumer connected and associated with a Subscription.
 #[derive(Debug)]
 pub(crate) struct Consumer {
-    pub(crate) consumer_id: u64,
-    pub(crate) consumer_name: String,
-    pub(crate) subscription_type: i32,
-    pub(crate) rx_broker: mpsc::Receiver<MessageToSend>,
-    pub(crate) tx_cons: mpsc::Sender<MessageToSend>,
+    consumer_id: u64,
+    consumer_name: String,
+    subscription_type: i32,
+    topic_name: String,
+    rx_broker: mpsc::Receiver<MessageToSend>,
+    tx_cons: mpsc::Sender<MessageToSend>,
     // status = true -> consumer OK, status = false -> Close the consumer
-    pub(crate) status: Arc<Mutex<bool>>,
+    status: Arc<Mutex<bool>>,
 }
 
 #[derive(Debug, Clone)]
@@ -32,6 +33,7 @@ impl Consumer {
         consumer_id: u64,
         consumer_name: &str,
         subscription_type: i32,
+        topic_name: &str,
         rx_broker: mpsc::Receiver<MessageToSend>,
         tx_cons: mpsc::Sender<MessageToSend>,
         status: Arc<Mutex<bool>>,
@@ -40,6 +42,7 @@ impl Consumer {
             consumer_id: consumer_id.into(),
             consumer_name: consumer_name.into(),
             subscription_type,
+            topic_name: topic_name.into(),
             rx_broker,
             tx_cons,
             status,
@@ -48,49 +51,30 @@ impl Consumer {
 
     // The consumer task runs asynchronously, handling message delivery to the gRPC `ReceiverStream`.
     pub(crate) async fn run(&mut self) {
+        while let Some(messages) = self.rx_broker.recv().await {
+            // Since u8 is exactly 1 byte, the size in bytes will be equal to the number of elements in the vector.
+            let payload_size = messages.payload.len();
+            // Send the message to the other channel
+            if let Err(err) = self.tx_cons.send(messages).await {
+                // Log the error and handle the channel closure scenario
+                warn!(
+                    "Failed to send message to consumer with id: {}. Error: {:?}",
+                    self.consumer_id, err
+                );
+
+                *self.status.lock().await = false
+            } else {
+                trace!("Sending the message over channel to {}", self.consumer_id);
+                counter!(CONSUMER_MSG_OUT_COUNTER.name, "topic"=> self.topic_name.clone() , "consumer" => self.consumer_id.to_string()).increment(1);
+                counter!(CONSUMER_BYTES_OUT_COUNTER.name, "topic"=> self.topic_name.clone() , "consumer" => self.consumer_id.to_string()).increment(payload_size as u64);
+            }
+        }
         info!("Consumer task ended for consumer_id: {}", self.consumer_id);
     }
 
-    // Dispatch a list of entries to the consumer.
-    // pub(crate) async fn send_messages(
-    //     &mut self,
-    //     messages: MessageToSend,
-    //     _batch_size: usize,
-    // ) -> Result<()> {
-    //     // let _unacked_messages = messages.len();
-    //     //Todo! here implement a logic to permit messages if the pendingAcks is under a threshold
-
-    //     // It attempts to send the message through the tx channel.
-    //     // If sending fails (e.g., if the client disconnects), it breaks the loop.
-    //     if let Some(tx) = &self.tx {
-    //         // Since u8 is exactly 1 byte, the size in bytes will be equal to the number of elements in the vector.
-    //         let payload_size = messages.payload.len();
-    //         if let Err(err) = tx.send(messages).await {
-    //             // Log the error and handle the channel closure scenario
-    //             warn!(
-    //                 "Failed to send message to consumer with id: {}. Error: {:?}",
-    //                 self.consumer_id, err
-    //             );
-
-    //             self.status = false
-    //         } else {
-    //             trace!("Sending the message over channel to {}", self.consumer_id);
-    //             counter!(CONSUMER_MSG_OUT_COUNTER.name, "topic"=> self.topic_name.clone() , "consumer" => self.consumer_id.to_string()).increment(1);
-    //             counter!(CONSUMER_BYTES_OUT_COUNTER.name, "topic"=> self.topic_name.clone() , "consumer" => self.consumer_id.to_string()).increment(payload_size as u64);
-    //         }
-    //     } else {
-    //         warn!(
-    //             "Unable to send the message to consumer: {} with id: {}, as the tx is not found",
-    //             self.consumer_name, self.consumer_id
-    //         );
-    //     };
-
-    //     Ok(())
+    // pub(crate) async fn get_status(&self) -> bool {
+    //     *self.status.lock().await
     // }
-
-    pub(crate) async fn get_status(&self) -> bool {
-        *self.status.lock().await
-    }
 
     // Close the consumer if: a. the connection is dropped
     // b. all messages were delivered and there are no pending message acks, graceful close connection
@@ -115,9 +99,9 @@ impl Consumer {
 
     // closes the consumer from server-side and inform the client through health_check mechanism
     // to disconnect consumer
-    pub(crate) fn disconnect(&mut self) -> u64 {
-        gauge!(TOPIC_CONSUMERS.name, "topic" => self.topic_name.to_string()).decrement(1);
-        self.status = false;
-        self.consumer_id
-    }
+    // pub(crate) async fn disconnect(&mut self) -> u64 {
+    //     gauge!(TOPIC_CONSUMERS.name, "topic" => self.topic_name.to_string()).decrement(1);
+    //     *self.status.lock().await = false;
+    //     self.consumer_id
+    // }
 }

--- a/danube-broker/src/consumer.rs
+++ b/danube-broker/src/consumer.rs
@@ -1,15 +1,16 @@
 use anyhow::Result;
-use metrics::{counter, gauge};
+use metrics::counter;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{info, trace, warn};
 
 use crate::{
-    broker_metrics::{CONSUMER_BYTES_OUT_COUNTER, CONSUMER_MSG_OUT_COUNTER, TOPIC_CONSUMERS},
+    broker_metrics::{CONSUMER_BYTES_OUT_COUNTER, CONSUMER_MSG_OUT_COUNTER},
     proto::MessageMetadata,
 };
 
 /// Represents a consumer connected and associated with a Subscription.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct Consumer {
     consumer_id: u64,

--- a/danube-broker/src/dispatcher.rs
+++ b/danube-broker/src/dispatcher.rs
@@ -23,16 +23,6 @@ impl Dispatcher {
             }
         }
     }
-    pub(crate) async fn disconnect_all_consumers(&self) -> Result<()> {
-        match self {
-            Dispatcher::OneConsumer(dispatcher) => {
-                Ok(dispatcher.disconnect_all_consumers().await?)
-            }
-            Dispatcher::MultipleConsumers(dispatcher) => {
-                Ok(dispatcher.disconnect_all_consumers().await?)
-            }
-        }
-    }
     pub(crate) async fn add_consumer(&mut self, consumer: ConsumerInfo) -> Result<()> {
         match self {
             Dispatcher::OneConsumer(dispatcher) => Ok(dispatcher.add_consumer(consumer).await?),
@@ -41,12 +31,13 @@ impl Dispatcher {
             }
         }
     }
-    #[allow(dead_code)]
-    pub(crate) async fn remove_consumer(&mut self, consumer: ConsumerInfo) -> Result<()> {
+    pub(crate) async fn remove_consumer(&mut self, consumer_id: u64) -> Result<()> {
         match self {
-            Dispatcher::OneConsumer(dispatcher) => Ok(dispatcher.remove_consumer(consumer).await?),
+            Dispatcher::OneConsumer(dispatcher) => {
+                Ok(dispatcher.remove_consumer(consumer_id).await?)
+            }
             Dispatcher::MultipleConsumers(dispatcher) => {
-                Ok(dispatcher.remove_consumer(consumer.consumer_id).await?)
+                Ok(dispatcher.remove_consumer(consumer_id).await?)
             }
         }
     }

--- a/danube-broker/src/dispatcher.rs
+++ b/danube-broker/src/dispatcher.rs
@@ -1,8 +1,6 @@
 use anyhow::Result;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 
-use crate::consumer::{Consumer, MessageToSend};
+use crate::{consumer::MessageToSend, subscription::ConsumerInfo};
 
 pub(crate) mod dispatcher_multiple_consumers;
 pub(crate) mod dispatcher_single_consumer;
@@ -25,7 +23,7 @@ impl Dispatcher {
             }
         }
     }
-    pub(crate) async fn disconnect_all_consumers(&self) -> Result<Vec<u64>> {
+    pub(crate) async fn disconnect_all_consumers(&self) -> Result<()> {
         match self {
             Dispatcher::OneConsumer(dispatcher) => {
                 Ok(dispatcher.disconnect_all_consumers().await?)
@@ -35,7 +33,7 @@ impl Dispatcher {
             }
         }
     }
-    pub(crate) async fn add_consumer(&mut self, consumer: Arc<Mutex<Consumer>>) -> Result<()> {
+    pub(crate) async fn add_consumer(&mut self, consumer: ConsumerInfo) -> Result<()> {
         match self {
             Dispatcher::OneConsumer(dispatcher) => Ok(dispatcher.add_consumer(consumer).await?),
             Dispatcher::MultipleConsumers(dispatcher) => {
@@ -44,7 +42,7 @@ impl Dispatcher {
         }
     }
     #[allow(dead_code)]
-    pub(crate) async fn remove_consumer(&mut self, consumer: Consumer) -> Result<()> {
+    pub(crate) async fn remove_consumer(&mut self, consumer: ConsumerInfo) -> Result<()> {
         match self {
             Dispatcher::OneConsumer(dispatcher) => Ok(dispatcher.remove_consumer(consumer).await?),
             Dispatcher::MultipleConsumers(dispatcher) => {
@@ -53,7 +51,7 @@ impl Dispatcher {
         }
     }
 
-    pub(crate) fn get_consumers(&self) -> &Vec<Arc<Mutex<Consumer>>> {
+    pub(crate) fn get_consumers(&self) -> &Vec<ConsumerInfo> {
         match self {
             Dispatcher::OneConsumer(dispatcher) => dispatcher.get_consumers(),
             Dispatcher::MultipleConsumers(dispatcher) => dispatcher.get_consumers(),

--- a/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
+++ b/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
@@ -52,10 +52,6 @@ impl DispatcherMultipleConsumers {
         &self.consumers
     }
 
-    pub(crate) async fn disconnect_all_consumers(&self) -> Result<()> {
-        Ok(())
-    }
-
     pub(crate) async fn send_messages(&self, messages: MessageToSend) -> Result<()> {
         // Attempt to get an active consumer and send messages
         if let Ok(consumer) = self.find_next_active_consumer().await {
@@ -77,7 +73,7 @@ impl DispatcherMultipleConsumers {
         for _ in 0..num_consumers {
             let consumer = self.get_next_consumer()?;
 
-            if !*consumer.status.lock().await {
+            if !consumer.get_status().await {
                 continue;
             }
 

--- a/danube-broker/src/dispatcher/dispatcher_single_consumer.rs
+++ b/danube-broker/src/dispatcher/dispatcher_single_consumer.rs
@@ -1,14 +1,13 @@
 use anyhow::{anyhow, Result};
-use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{mpsc, RwLock};
 use tracing::{trace, warn};
 
-use crate::consumer::{Consumer, MessageToSend};
+use crate::consumer::MessageToSend;
 
 #[derive(Debug)]
 pub(crate) struct DispatcherSingleConsumer {
-    consumers: Vec<Arc<Mutex<Consumer>>>,
-    active_consumer: RwLock<Option<Arc<Mutex<Consumer>>>>,
+    consumers: Vec<(u64, mpsc::Sender<MessageToSend>)>,
+    active_consumer: RwLock<Option<(u64, mpsc::Sender<MessageToSend>)>>,
 }
 
 impl DispatcherSingleConsumer {
@@ -26,12 +25,8 @@ impl DispatcherSingleConsumer {
         let mut candidate = None;
 
         for consumer in &self.consumers {
-            let guard = consumer.lock().await;
-            // validates that the consumer has called the receive methods which populates the Consumer tx field
-            if guard.tx.is_some() && guard.status {
-                candidate = Some(consumer.clone());
-                break;
-            }
+            // validates somehow that the consumer has called the receive methods and is valid
+            candidate = Some((consumer.0, consumer.1.clone()));
         }
 
         if let Some(consumer) = candidate {
@@ -59,12 +54,8 @@ impl DispatcherSingleConsumer {
         // 2. filter the messages for consumers
         // 3. other permits like dispatch rate limiter, quota etc
 
-        let mut consumer_guard = active_consumer.lock().await;
-
         // check if the consumer is active
-        if !consumer_guard.status {
-            drop(consumer_guard);
-
+        if !active_consumer.status {
             // Pick a new active consumer
             if !self.pick_active_consumer().await {
                 return Err(anyhow!(
@@ -72,36 +63,37 @@ impl DispatcherSingleConsumer {
                 ));
             }
         } else {
-            consumer_guard.send_messages(messages, 1).await?;
+            active_consumer.1.send(messages).await?;
         }
 
         Ok(())
     }
 
     // manage the addition of consumers to the dispatcher
-    pub(crate) async fn add_consumer(&mut self, consumer: Arc<Mutex<Consumer>>) -> Result<()> {
+    pub(crate) async fn add_consumer(
+        &mut self,
+        consumer_id: u64,
+        tx_broker: mpsc::Sender<MessageToSend>,
+    ) -> Result<()> {
         // Handle Exclusive Subscription
         // The consumer addition is not allowed if there are consumers in the list and Subscription is Exclusive
         let consumer_subscription_type;
 
-        {
-            let consumer_guard = consumer.lock().await;
-            consumer_subscription_type = consumer_guard.subscription_type;
+        // if the subscription is Shared should not be routed to this dispatcher
+        if consumer_subscription_type == 1 {
+            return Err(anyhow!(
+                "Erroneous routing, Shared subscription should use dispatcher multiple consumer"
+            ));
+        }
 
-            // if the subscription is Shared should not be routed to this dispatcher
-            if consumer_subscription_type == 1 {
-                return Err(anyhow!("Erroneous routing, Shared subscription should use dispatcher multiple consumer"));
-            }
-
-            if consumer_subscription_type == 0 && !self.consumers.is_empty() {
-                // connect to active consumer self.active_consumer
-                warn!("Not allowed to add the Consumer: {}, the Exclusive subscription can't be shared with other consumers", consumer_guard.consumer_id);
-                return Err(anyhow!("Not allowed to add the Consumer, the Exclusive subscription can't be shared with other consumers"));
-            }
+        if consumer_subscription_type == 0 && !self.consumers.is_empty() {
+            // connect to active consumer self.active_consumer
+            warn!("Not allowed to add the Consumer: {}, the Exclusive subscription can't be shared with other consumers", consumer_guard.consumer_id);
+            return Err(anyhow!("Not allowed to add the Consumer, the Exclusive subscription can't be shared with other consumers"));
         }
 
         if self.consumers.is_empty() {
-            self.active_consumer = Some(consumer.clone()).into()
+            self.active_consumer = Some((consumer_id, tx_broker)).into()
         } else {
             if !self.pick_active_consumer().await {
                 return Err(anyhow!("Unable to pick an active Consumer"));
@@ -109,49 +101,12 @@ impl DispatcherSingleConsumer {
         }
 
         // add Exclusive and Failover consumer to dispatcher
-        self.consumers.push(consumer.clone());
-
-        let consumer_name;
-
-        {
-            let consumer_guard = consumer.lock().await;
-            consumer_name = consumer_guard.consumer_name.clone();
-        }
+        self.consumers.push((consumer_id, tx_broker));
 
         trace!(
             "The dispatcher DispatcherSingleConsumer has added the consumer {}",
-            consumer_name
+            consumer_id
         );
-
-        Ok(())
-    }
-
-    // manage the removal of consumers from the dispatcher
-    #[allow(dead_code)]
-    pub(crate) async fn remove_consumer(&mut self, consumer: Consumer) -> Result<()> {
-        // Find the position asynchronously
-        let pos = {
-            let mut pos = None;
-            for (index, x) in self.consumers.iter().enumerate() {
-                if x.lock().await.consumer_id == consumer.consumer_id {
-                    pos = Some(index);
-                    break;
-                }
-            }
-            pos
-        };
-
-        // If a position was found, remove the consumer at that position
-        if let Some(pos) = pos {
-            self.consumers.remove(pos);
-        }
-
-        // Check if the consumers list is empty and update the active consumer
-        if self.consumers.is_empty() {
-            self.active_consumer = None.into();
-        }
-
-        let _ = self.pick_active_consumer();
 
         Ok(())
     }
@@ -160,13 +115,16 @@ impl DispatcherSingleConsumer {
         let mut consumers = Vec::new();
 
         for consumer in self.consumers.iter() {
-            let consumer_id = consumer.lock().await.disconnect();
-            consumers.push(consumer_id)
+            consumers.push(consumer.0)
         }
         Ok(consumers)
     }
 
-    pub(crate) fn get_consumers(&self) -> &Vec<Arc<Mutex<Consumer>>> {
-        &self.consumers
+    pub(crate) fn get_consumers(&self) -> Vec<u64> {
+        let mut consumer_list = Vec::new();
+        for consumer in &self.consumers {
+            consumer_list.push(consumer.0);
+        }
+        consumer_list
     }
 }

--- a/danube-broker/src/subscription.rs
+++ b/danube-broker/src/subscription.rs
@@ -1,15 +1,16 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tracing::trace;
 
 use crate::{
-    consumer::Consumer,
+    consumer::{Consumer, MessageToSend},
     dispatcher::{
         dispatcher_multiple_consumers::DispatcherMultipleConsumers,
         dispatcher_single_consumer::DispatcherSingleConsumer, Dispatcher,
     },
+    utils::get_random_id,
 };
 
 // Subscriptions manage the consumers that are subscribed to them.
@@ -18,8 +19,17 @@ use crate::{
 pub(crate) struct Subscription {
     pub(crate) subscription_name: String,
     pub(crate) subscription_type: i32,
-    // the consumers registered to the subscription, consumer_id -> Consumer
-    pub(crate) consumers: HashMap<u64, Arc<Mutex<Consumer>>>,
+    // Each consumer has a `mpsc::Sender` channel for sending messages
+    pub(crate) consumers: HashMap<
+        u64,
+        (
+            //this is used by broker to send messages
+            mpsc::Sender<MessageToSend>,
+            //this is used on the client side
+            Arc<Mutex<mpsc::Receiver<MessageToSend>>>,
+            tokio::task::JoinHandle<()>,
+        ),
+    >,
     pub(crate) dispatcher: Option<Dispatcher>,
 }
 
@@ -45,22 +55,36 @@ impl Subscription {
         }
     }
     // Adds a consumer to the subscription
-    pub(crate) async fn add_consumer(&mut self, consumer: Arc<Mutex<Consumer>>) -> Result<()> {
-        // Retrieve the subscription type and consumer ID without holding the lock for too long
-        let (subscription_type, consumer_id);
+    pub(crate) async fn add_consumer(
+        &mut self,
+        topic_name: &str,
+        options: SubscriptionOptions,
+    ) -> Result<u64> {
+        // for communication with broker
+        let (tx_broker, rx_broker) = mpsc::channel(4);
+        //for communication with client consumer
+        let (tx_cons, rx_cons) = mpsc::channel(4);
 
-        {
-            let consumer_guard = consumer.lock().await;
-            subscription_type = consumer_guard.subscription_type;
-            consumer_id = consumer_guard.consumer_id;
-        }
+        let consumer_id = get_random_id();
+        let mut consumer = Consumer::new(
+            topic_name,
+            consumer_id,
+            &options.consumer_name,
+            &options.subscription_name,
+            options.subscription_type,
+        );
+
+        // Spawn consumer task
+        let handle = tokio::spawn(async move {
+            consumer.run(rx_broker, tx_cons, consumer_id).await;
+        });
 
         // checks if there'a a dispatcher (responsible for distributing messages to consumers)
         // if not initialize a new dispatcher based on the subscription type: Exclusive, Shared, Failover
         let dispatcher = if let Some(dispatcher) = self.dispatcher.as_mut() {
             dispatcher
         } else {
-            let new_dispatcher = match subscription_type {
+            let new_dispatcher = match options.subscription_type {
                 // Exclusive
                 0 => Dispatcher::OneConsumer(DispatcherSingleConsumer::new()),
 
@@ -82,10 +106,13 @@ impl Subscription {
         };
 
         // Insert the consumer into the subscription's consumer list
-        self.consumers.insert(consumer_id, consumer.clone());
+        self.consumers.insert(
+            consumer_id,
+            (tx_broker, Arc::new(Mutex::new(rx_cons)), handle),
+        );
 
         // Add the consumer to the dispatcher
-        dispatcher.add_consumer(consumer.clone()).await?;
+        dispatcher.add_consumer(consumer_id, tx_broker).await?;
 
         trace!(
             "A dispatcher {:?} has been added on subscription {}",
@@ -93,7 +120,17 @@ impl Subscription {
             self.subscription_name
         );
 
-        Ok(())
+        Ok(consumer_id)
+    }
+
+    pub(crate) fn get_consumer_rx(
+        &self,
+        consumer_id: u64,
+    ) -> Option<Arc<Mutex<mpsc::Receiver<MessageToSend>>>> {
+        if let Some(consumer) = self.consumers.get(&consumer_id) {
+            return Some(consumer.1.clone());
+        }
+        None
     }
 
     // remove a consumer from the subscription

--- a/danube-broker/src/topic.rs
+++ b/danube-broker/src/topic.rs
@@ -240,8 +240,7 @@ impl Topic {
         let consumers = disp.get_consumers();
 
         for consumer in consumers {
-            let cons_guard = consumer.lock().await;
-            if cons_guard.status {
+            if *consumer.status.lock().await {
                 return Some(true);
             }
         }

--- a/danube-broker/src/topic.rs
+++ b/danube-broker/src/topic.rs
@@ -1,21 +1,17 @@
 use anyhow::{anyhow, Result};
 use metrics::counter;
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    sync::Arc,
-};
+use std::collections::{hash_map::Entry, HashMap};
 use tokio::sync::Mutex;
 use tracing::{info, trace, warn};
 
 use crate::proto::MessageMetadata;
 use crate::{
     broker_metrics::{TOPIC_BYTES_IN_COUNTER, TOPIC_MSG_IN_COUNTER},
-    consumer::{Consumer, MessageToSend},
+    consumer::MessageToSend,
     policies::Policies,
     producer::Producer,
     schema::Schema,
     subscription::{Subscription, SubscriptionOptions},
-    utils::get_random_id,
 };
 
 pub(crate) static SYSTEM_TOPIC: &str = "/system/_events_topic";
@@ -187,7 +183,7 @@ impl Topic {
         &self,
         topic_name: &str,
         options: SubscriptionOptions,
-    ) -> Result<Arc<Mutex<Consumer>>> {
+    ) -> Result<u64> {
         //Todo! sub_metadata is user-defined information to the subscription,
         //maybe for user internal business, management and montoring
         let sub_metadata = HashMap::new();
@@ -203,22 +199,11 @@ impl Topic {
             return Err(anyhow!("Not allowed to add the Consumer: {}, the Exclusive subscription can't be shared with other consumers", options.consumer_name));
         }
 
-        let consumer_id = get_random_id();
-
-        let consumer = Arc::new(Mutex::new(Consumer::new(
-            topic_name,
-            consumer_id,
-            options.consumer_name.as_str(),
-            options.subscription_name.clone().as_str(),
-            options.subscription_type,
-        )));
-
         //Todo! Check the topic policies with max_consumers per topic
 
-        // is it ok to clone ? .. or should return just the ID, or ARC
-        subscription.add_consumer(consumer.clone()).await?;
+        let consumer_id = subscription.add_consumer(topic_name, options).await?;
 
-        Ok(consumer)
+        Ok(consumer_id)
     }
 
     // Unsubscribes the specified subscription from the topic


### PR DESCRIPTION
instead of using mutex locks to send message to each consumer, I spawned a separate tokio task for each consumer. In this way the consumer will operate independently of the main thread and also it prepares the terrain for using reliable messages in the future.