### PR TITLE
Run dispatcher in a separate task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Cargo.lock
 
 etcd-data/
 temp/
+.vscode/

--- a/danube-broker/src/consumer.rs
+++ b/danube-broker/src/consumer.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use metrics::counter;
+use metrics::{counter, gauge};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{trace, warn};
 
 use crate::{
-    broker_metrics::{CONSUMER_BYTES_OUT_COUNTER, CONSUMER_MSG_OUT_COUNTER},
+    broker_metrics::{CONSUMER_BYTES_OUT_COUNTER, CONSUMER_MSG_OUT_COUNTER, TOPIC_CONSUMERS},
     proto::MessageMetadata,
 };
 
@@ -97,9 +97,9 @@ impl Consumer {
 
     // closes the consumer from server-side and inform the client through health_check mechanism
     // to disconnect consumer
-    // pub(crate) async fn disconnect(&mut self) -> u64 {
-    //     gauge!(TOPIC_CONSUMERS.name, "topic" => self.topic_name.to_string()).decrement(1);
-    //     *self.status.lock().await = false;
-    //     self.consumer_id
-    // }
+    pub(crate) async fn disconnect(&mut self) -> u64 {
+        gauge!(TOPIC_CONSUMERS.name, "topic" => self.topic_name.to_string()).decrement(1);
+        *self.status.lock().await = false;
+        self.consumer_id
+    }
 }

--- a/danube-broker/src/consumer.rs
+++ b/danube-broker/src/consumer.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use metrics::{counter, gauge};
+use metrics::counter;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{trace, warn};
 
 use crate::{
-    broker_metrics::{CONSUMER_BYTES_OUT_COUNTER, CONSUMER_MSG_OUT_COUNTER, TOPIC_CONSUMERS},
+    broker_metrics::{CONSUMER_BYTES_OUT_COUNTER, CONSUMER_MSG_OUT_COUNTER},
     proto::MessageMetadata,
 };
 
@@ -72,34 +72,5 @@ impl Consumer {
 
     pub(crate) async fn get_status(&self) -> bool {
         *self.status.lock().await
-    }
-
-    // Close the consumer if: a. the connection is dropped
-    // b. all messages were delivered and there are no pending message acks, graceful close connection
-    #[allow(dead_code)]
-    pub(crate) fn close(&self) -> Result<()> {
-        // subscription.remove_consumer(self)
-        todo!()
-    }
-
-    // Unsubscribe consumer from the Subscription
-    #[allow(dead_code)]
-    pub(crate) fn unsubscribe(&self) -> Result<()> {
-        // subscription.unsubscribe(self)
-        todo!()
-    }
-
-    // acked message from client
-    #[allow(dead_code)]
-    pub(crate) fn message_acked(&self) -> Result<()> {
-        todo!()
-    }
-
-    // closes the consumer from server-side and inform the client through health_check mechanism
-    // to disconnect consumer
-    pub(crate) async fn disconnect(&mut self) -> u64 {
-        gauge!(TOPIC_CONSUMERS.name, "topic" => self.topic_name.to_string()).decrement(1);
-        *self.status.lock().await = false;
-        self.consumer_id
     }
 }

--- a/danube-broker/src/consumer.rs
+++ b/danube-broker/src/consumer.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use metrics::counter;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
-use tracing::{info, trace, warn};
+use tracing::{trace, warn};
 
 use crate::{
     broker_metrics::{CONSUMER_BYTES_OUT_COUNTER, CONSUMER_MSG_OUT_COUNTER},
@@ -13,14 +13,13 @@ use crate::{
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct Consumer {
-    consumer_id: u64,
-    consumer_name: String,
-    subscription_type: i32,
-    topic_name: String,
-    rx_broker: mpsc::Receiver<MessageToSend>,
-    tx_cons: mpsc::Sender<MessageToSend>,
+    pub(crate) consumer_id: u64,
+    pub(crate) consumer_name: String,
+    pub(crate) subscription_type: i32,
+    pub(crate) topic_name: String,
+    pub(crate) tx_cons: mpsc::Sender<MessageToSend>,
     // status = true -> consumer OK, status = false -> Close the consumer
-    status: Arc<Mutex<bool>>,
+    pub(crate) status: Arc<Mutex<bool>>,
 }
 
 #[derive(Debug, Clone)]
@@ -35,7 +34,6 @@ impl Consumer {
         consumer_name: &str,
         subscription_type: i32,
         topic_name: &str,
-        rx_broker: mpsc::Receiver<MessageToSend>,
         tx_cons: mpsc::Sender<MessageToSend>,
         status: Arc<Mutex<bool>>,
     ) -> Self {
@@ -44,38 +42,37 @@ impl Consumer {
             consumer_name: consumer_name.into(),
             subscription_type,
             topic_name: topic_name.into(),
-            rx_broker,
             tx_cons,
             status,
         }
     }
 
     // The consumer task runs asynchronously, handling message delivery to the gRPC `ReceiverStream`.
-    pub(crate) async fn run(&mut self) {
-        while let Some(messages) = self.rx_broker.recv().await {
-            // Since u8 is exactly 1 byte, the size in bytes will be equal to the number of elements in the vector.
-            let payload_size = messages.payload.len();
-            // Send the message to the other channel
-            if let Err(err) = self.tx_cons.send(messages).await {
-                // Log the error and handle the channel closure scenario
-                warn!(
-                    "Failed to send message to consumer with id: {}. Error: {:?}",
-                    self.consumer_id, err
-                );
+    pub(crate) async fn send_message(&mut self, message: MessageToSend) -> Result<()> {
+        // Since u8 is exactly 1 byte, the size in bytes will be equal to the number of elements in the vector.
+        let payload_size = message.payload.len();
+        // Send the message to the other channel
+        if let Err(err) = self.tx_cons.send(message).await {
+            // Log the error and handle the channel closure scenario
+            warn!(
+                "Failed to send message to consumer with id: {}. Error: {:?}",
+                self.consumer_id, err
+            );
 
-                *self.status.lock().await = false
-            } else {
-                trace!("Sending the message over channel to {}", self.consumer_id);
-                counter!(CONSUMER_MSG_OUT_COUNTER.name, "topic"=> self.topic_name.clone() , "consumer" => self.consumer_id.to_string()).increment(1);
-                counter!(CONSUMER_BYTES_OUT_COUNTER.name, "topic"=> self.topic_name.clone() , "consumer" => self.consumer_id.to_string()).increment(payload_size as u64);
-            }
+            *self.status.lock().await = false
+        } else {
+            trace!("Sending the message over channel to {}", self.consumer_id);
+            counter!(CONSUMER_MSG_OUT_COUNTER.name, "topic"=> self.topic_name.clone() , "consumer" => self.consumer_id.to_string()).increment(1);
+            counter!(CONSUMER_BYTES_OUT_COUNTER.name, "topic"=> self.topic_name.clone() , "consumer" => self.consumer_id.to_string()).increment(payload_size as u64);
         }
-        info!("Consumer task ended for consumer_id: {}", self.consumer_id);
+
+        // info!("Consumer task ended for consumer_id: {}", self.consumer_id);
+        Ok(())
     }
 
-    // pub(crate) async fn get_status(&self) -> bool {
-    //     *self.status.lock().await
-    // }
+    pub(crate) async fn get_status(&self) -> bool {
+        *self.status.lock().await
+    }
 
     // Close the consumer if: a. the connection is dropped
     // b. all messages were delivered and there are no pending message acks, graceful close connection

--- a/danube-broker/src/consumer.rs
+++ b/danube-broker/src/consumer.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// Represents a consumer connected and associated with a Subscription.
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Consumer {
     pub(crate) consumer_id: u64,
     pub(crate) consumer_name: String,

--- a/danube-broker/src/dispatcher.rs
+++ b/danube-broker/src/dispatcher.rs
@@ -29,16 +29,16 @@ impl Dispatcher {
             }
         }
     }
-    pub(crate) async fn remove_consumer(&mut self, consumer_id: u64) -> Result<()> {
-        match self {
-            Dispatcher::OneConsumer(dispatcher) => {
-                Ok(dispatcher.remove_consumer(consumer_id).await?)
-            }
-            Dispatcher::MultipleConsumers(dispatcher) => {
-                Ok(dispatcher.remove_consumer(consumer_id).await?)
-            }
-        }
-    }
+    // pub(crate) async fn remove_consumer(&mut self, consumer_id: u64) -> Result<()> {
+    //     match self {
+    //         Dispatcher::OneConsumer(dispatcher) => {
+    //             Ok(dispatcher.remove_consumer(consumer_id).await?)
+    //         }
+    //         Dispatcher::MultipleConsumers(dispatcher) => {
+    //             Ok(dispatcher.remove_consumer(consumer_id).await?)
+    //         }
+    //     }
+    // }
 
     pub(crate) async fn disconnect_all_consumers(&mut self) -> Result<Vec<u64>> {
         match self {

--- a/danube-broker/src/dispatcher.rs
+++ b/danube-broker/src/dispatcher.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use tokio::sync::mpsc;
 
 use crate::consumer::{Consumer, MessageToSend};
 
@@ -7,20 +6,6 @@ pub(crate) mod dispatcher_multiple_consumers;
 pub(crate) mod dispatcher_single_consumer;
 pub(crate) use dispatcher_multiple_consumers::DispatcherMultipleConsumers;
 pub(crate) use dispatcher_single_consumer::DispatcherSingleConsumer;
-
-#[derive(Debug)]
-pub(crate) struct DispatcherInfo {
-    pub(crate) dispatcher_handle: tokio::task::JoinHandle<()>,
-    pub(crate) dispatcher_tx: mpsc::Sender<DispatcherCommand>,
-}
-
-#[derive(Debug)]
-pub(crate) enum DispatcherCommand {
-    AddConsumer(Consumer),
-    RemoveConsumer(u64),
-    Dispatch(MessageToSend),
-    Shutdown,
-}
 
 // The dispatchers ensure that messages are routed to consumers according to the semantics of the subscription type
 #[derive(Debug)]
@@ -34,6 +19,42 @@ impl Dispatcher {
         match self {
             Dispatcher::OneConsumer(dispatcher) => Ok(dispatcher.run().await?),
             Dispatcher::MultipleConsumers(dispatcher) => Ok(dispatcher.run().await?),
+        }
+    }
+    pub(crate) async fn add_consumer(&mut self, consumer: Consumer) -> Result<()> {
+        match self {
+            Dispatcher::OneConsumer(dispatcher) => Ok(dispatcher.add_consumer(consumer).await?),
+            Dispatcher::MultipleConsumers(dispatcher) => {
+                Ok(dispatcher.add_consumer(consumer).await?)
+            }
+        }
+    }
+    pub(crate) async fn remove_consumer(&mut self, consumer_id: u64) -> Result<()> {
+        match self {
+            Dispatcher::OneConsumer(dispatcher) => {
+                Ok(dispatcher.remove_consumer(consumer_id).await?)
+            }
+            Dispatcher::MultipleConsumers(dispatcher) => {
+                Ok(dispatcher.remove_consumer(consumer_id).await?)
+            }
+        }
+    }
+
+    pub(crate) async fn disconnect_all_consumers(&self) -> Result<Vec<u64>> {
+        match self {
+            Dispatcher::OneConsumer(dispatcher) => {
+                Ok(dispatcher.disconnect_all_consumers().await?)
+            }
+            Dispatcher::MultipleConsumers(dispatcher) => {
+                Ok(dispatcher.disconnect_all_consumers().await?)
+            }
+        }
+    }
+
+    pub(crate) fn get_consumers(&self) -> &Vec<Consumer> {
+        match self {
+            Dispatcher::OneConsumer(dispatcher) => dispatcher.get_consumers(),
+            Dispatcher::MultipleConsumers(dispatcher) => dispatcher.get_consumers(),
         }
     }
 }

--- a/danube-broker/src/dispatcher.rs
+++ b/danube-broker/src/dispatcher.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::consumer::{Consumer, MessageToSend};
+use crate::consumer::Consumer;
 
 pub(crate) mod dispatcher_multiple_consumers;
 pub(crate) mod dispatcher_single_consumer;
@@ -15,7 +15,7 @@ pub(crate) enum Dispatcher {
 }
 
 impl Dispatcher {
-    pub(crate) async fn run(&self) -> Result<()> {
+    pub(crate) async fn run(&mut self) -> Result<()> {
         match self {
             Dispatcher::OneConsumer(dispatcher) => Ok(dispatcher.run().await?),
             Dispatcher::MultipleConsumers(dispatcher) => Ok(dispatcher.run().await?),
@@ -40,7 +40,7 @@ impl Dispatcher {
         }
     }
 
-    pub(crate) async fn disconnect_all_consumers(&self) -> Result<Vec<u64>> {
+    pub(crate) async fn disconnect_all_consumers(&mut self) -> Result<Vec<u64>> {
         match self {
             Dispatcher::OneConsumer(dispatcher) => {
                 Ok(dispatcher.disconnect_all_consumers().await?)

--- a/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
+++ b/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
@@ -1,18 +1,19 @@
 use anyhow::{anyhow, Result};
-use std::sync::{atomic::AtomicUsize, mpsc::Receiver};
+use std::sync::{atomic::AtomicUsize, Arc};
+use tokio::sync::{mpsc::Receiver, Mutex};
 use tracing::trace;
 
-use crate::{consumer::MessageToSend, dispatcher::DispatcherCommand, subscription::ConsumerInfo};
+use crate::consumer::{Consumer, MessageToSend};
 
 #[derive(Debug)]
 pub(crate) struct DispatcherMultipleConsumers {
     consumers: Vec<Consumer>,
     index_consumer: AtomicUsize,
-    rx_disp: Receiver<DispatcherCommand>,
+    rx_disp: Arc<Mutex<Receiver<MessageToSend>>>,
 }
 
 impl DispatcherMultipleConsumers {
-    pub(crate) fn new(rx_disp: Receiver<DispatcherCommand>) -> Self {
+    pub(crate) fn new(rx_disp: Arc<Mutex<Receiver<MessageToSend>>>) -> Self {
         DispatcherMultipleConsumers {
             consumers: Vec::new(),
             index_consumer: AtomicUsize::new(0),
@@ -20,12 +21,94 @@ impl DispatcherMultipleConsumers {
         }
     }
 
+    pub(crate) async fn run(&mut self) -> Result<()> {
+        let rx_disp_cloned = self.rx_disp.clone();
+        tokio::spawn(async move {
+            loop {
+                let mut rx = rx_disp_cloned.lock().await;
+                if let Some(_message) = rx.recv().await {
+                    todo!();
+                };
+            }
+        });
+        Ok(())
+    }
+
     // manage the addition of consumers to the dispatcher
-    pub(crate) async fn add_consumer(&mut self, consumer: ConsumerInfo) -> Result<()> {
+    pub(crate) async fn add_consumer(&mut self, consumer: Consumer) -> Result<()> {
         // checks if adding a new consumer would exceed the maximum allowed consumers for the subscription
         self.consumers.push(consumer);
 
         Ok(())
+    }
+
+    pub(crate) fn get_consumers(&self) -> &Vec<Consumer> {
+        &self.consumers
+    }
+
+    // pub(crate) async fn send_messages(&self, messages: MessageToSend) -> Result<()> {
+    //     // Attempt to get an active consumer and send messages
+    //     if let Ok(consumer) = self.find_next_active_consumer().await {
+    //         //let batch_size = 1; // to be calculated
+    //         consumer.tx_broker.send(messages).await?;
+    //         trace!(
+    //             "Dispatcher is sending the message to consumer: {}",
+    //             consumer.consumer_id
+    //         );
+    //         Ok(())
+    //     } else {
+    //         Err(anyhow!("There are no active consumers on this dispatcher"))
+    //     }
+    // }
+
+    async fn find_next_active_consumer(&self) -> Result<Consumer> {
+        let num_consumers = self.consumers.len();
+
+        for _ in 0..num_consumers {
+            let consumer = self.get_next_consumer()?;
+
+            if !consumer.get_status().await {
+                continue;
+            }
+
+            return Ok(consumer);
+        }
+
+        return Err(anyhow!("unable to find an active consumer"));
+    }
+
+    pub(crate) fn get_next_consumer(&self) -> Result<Consumer> {
+        let num_consumers = self.consumers.len();
+
+        if num_consumers == 0 {
+            return Err(anyhow!("There are no consumers left"));
+        }
+
+        // Use modulo to ensure index wraps around
+        let index = self
+            .index_consumer
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            % num_consumers;
+
+        // Get the consumer at the computed index
+        self.consumers
+            .get(index)
+            .cloned() // Clone the Arc<Mutex<Consumer>> to return
+            .ok_or_else(|| anyhow!("Unable to find the next consumer"))
+    }
+
+    pub(crate) async fn disconnect_all_consumers(&mut self) -> Result<Vec<u64>> {
+        let mut consumers = Vec::new();
+
+        for consumer in self.consumers.iter() {
+            consumers.push(consumer.consumer_id)
+        }
+
+        for consumer_id in consumers.iter() {
+            self.remove_consumer(consumer_id.clone()).await?;
+        }
+
+        Ok(consumers)
     }
 
     // manage the removal of consumers from the dispatcher
@@ -48,60 +131,5 @@ impl DispatcherMultipleConsumers {
         }
 
         Ok(())
-    }
-
-    pub(crate) fn get_consumers(&self) -> &Vec<ConsumerInfo> {
-        &self.consumers
-    }
-
-    pub(crate) async fn send_messages(&self, messages: MessageToSend) -> Result<()> {
-        // Attempt to get an active consumer and send messages
-        if let Ok(consumer) = self.find_next_active_consumer().await {
-            //let batch_size = 1; // to be calculated
-            consumer.tx_broker.send(messages).await?;
-            trace!(
-                "Dispatcher is sending the message to consumer: {}",
-                consumer.consumer_id
-            );
-            Ok(())
-        } else {
-            Err(anyhow!("There are no active consumers on this dispatcher"))
-        }
-    }
-
-    async fn find_next_active_consumer(&self) -> Result<ConsumerInfo> {
-        let num_consumers = self.consumers.len();
-
-        for _ in 0..num_consumers {
-            let consumer = self.get_next_consumer()?;
-
-            if !consumer.get_status().await {
-                continue;
-            }
-
-            return Ok(consumer);
-        }
-
-        return Err(anyhow!("unable to find an active consumer"));
-    }
-
-    pub(crate) fn get_next_consumer(&self) -> Result<ConsumerInfo> {
-        let num_consumers = self.consumers.len();
-
-        if num_consumers == 0 {
-            return Err(anyhow!("There are no consumers left"));
-        }
-
-        // Use modulo to ensure index wraps around
-        let index = self
-            .index_consumer
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
-            % num_consumers;
-
-        // Get the consumer at the computed index
-        self.consumers
-            .get(index)
-            .cloned() // Clone the Arc<Mutex<Consumer>> to return
-            .ok_or_else(|| anyhow!("Unable to find the next consumer"))
     }
 }

--- a/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
+++ b/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
@@ -1,136 +1,121 @@
 use anyhow::{anyhow, Result};
-use std::sync::{atomic::AtomicUsize, Arc};
-use tokio::sync::{mpsc::Receiver, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::mpsc;
 use tracing::{trace, warn};
 
-use crate::consumer::{Consumer, MessageToSend};
+use crate::{
+    consumer::{Consumer, MessageToSend},
+    dispatcher::DispatcherCommand,
+};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct DispatcherMultipleConsumers {
-    consumers: Vec<Consumer>,
-    index_consumer: Arc<AtomicUsize>,
-    rx_disp: Arc<Mutex<Receiver<MessageToSend>>>,
+    control_tx: mpsc::Sender<DispatcherCommand>,
 }
 
 impl DispatcherMultipleConsumers {
-    pub(crate) fn new(rx_disp: Arc<Mutex<Receiver<MessageToSend>>>) -> Self {
-        DispatcherMultipleConsumers {
-            consumers: Vec::new(),
-            index_consumer: Arc::new(AtomicUsize::new(0)),
-            rx_disp,
-        }
-    }
+    pub(crate) fn new() -> Self {
+        let (control_tx, mut control_rx) = mpsc::channel(16);
 
-    pub(crate) async fn run(&mut self) -> Result<()> {
-        let rx_disp_cloned = self.rx_disp.clone();
-        let dispatcher = Arc::new(self.clone());
+        // Spawn the dispatcher task
         tokio::spawn(async move {
+            let mut consumers: Vec<Consumer> = Vec::new();
+            let mut index_consumer = AtomicUsize::new(0);
+
             loop {
-                let mut rx = rx_disp_cloned.lock().await;
-                if let Some(message) = rx.recv().await {
-                    if let Err(error) = dispatcher.send_messages(message).await {
-                        warn!("Error sending messages: {}", error);
-                    };
+                if let Some(command) = control_rx.recv().await {
+                    match command {
+                        DispatcherCommand::AddConsumer(consumer) => {
+                            consumers.push(consumer);
+                            trace!("Consumer added. Total consumers: {}", consumers.len());
+                        }
+                        DispatcherCommand::RemoveConsumer(consumer_id) => {
+                            consumers.retain(|c| c.consumer_id != consumer_id);
+                            trace!("Consumer removed. Total consumers: {}", consumers.len());
+                        }
+                        DispatcherCommand::DisconnectAllConsumers => {
+                            consumers.clear();
+                            trace!("All consumers disconnected.");
+                        }
+                        DispatcherCommand::DispatchMessage(message) => {
+                            if let Err(error) = Self::handle_dispatch_message(
+                                &mut consumers,
+                                &mut index_consumer,
+                                message,
+                            )
+                            .await
+                            {
+                                warn!("Failed to dispatch message: {}", error);
+                            }
+                        }
+                    }
                 }
             }
         });
-        Ok(())
+
+        DispatcherMultipleConsumers { control_tx }
     }
 
-    // manage the addition of consumers to the dispatcher
-    pub(crate) async fn add_consumer(&mut self, consumer: Consumer) -> Result<()> {
-        // checks if adding a new consumer would exceed the maximum allowed consumers for the subscription
-        self.consumers.push(consumer);
-
-        Ok(())
+    /// Dispatch a message to the active consumer
+    pub(crate) async fn dispatch_message(&self, message: MessageToSend) -> Result<()> {
+        self.control_tx
+            .send(DispatcherCommand::DispatchMessage(message))
+            .await
+            .map_err(|err| anyhow!("Failed to dispatch the message {}", err))
     }
 
-    pub(crate) fn get_consumers(&self) -> &Vec<Consumer> {
-        &self.consumers
+    /// Add a new consumer to the dispatcher
+    pub(crate) async fn add_consumer(&self, consumer: Consumer) -> Result<()> {
+        self.control_tx
+            .send(DispatcherCommand::AddConsumer(consumer))
+            .await
+            .map_err(|_| anyhow!("Failed to send add consumer command"))
     }
 
-    pub(crate) async fn send_messages(&self, messages: MessageToSend) -> Result<()> {
-        // Attempt to get an active consumer and send messages
-        if let Ok(mut consumer) = self.find_next_active_consumer().await {
-            consumer.send_message(messages).await?;
-            trace!(
-                "Dispatcher is sending the message to consumer: {}",
-                consumer.consumer_id
-            );
-            Ok(())
-        } else {
-            Err(anyhow!("There are no active consumers on this dispatcher"))
+    /// Remove a consumer by its ID
+    #[allow(dead_code)]
+    pub(crate) async fn remove_consumer(&self, consumer_id: u64) -> Result<()> {
+        self.control_tx
+            .send(DispatcherCommand::RemoveConsumer(consumer_id))
+            .await
+            .map_err(|_| anyhow!("Failed to send remove consumer command"))
+    }
+
+    /// Disconnect all consumers
+    pub(crate) async fn disconnect_all_consumers(&self) -> Result<()> {
+        self.control_tx
+            .send(DispatcherCommand::DisconnectAllConsumers)
+            .await
+            .map_err(|_| anyhow!("Failed to send disconnect all consumers command"))
+    }
+
+    /// Dispatch message helper method
+    async fn handle_dispatch_message(
+        consumers: &mut [Consumer],
+        index_consumer: &mut AtomicUsize,
+        message: MessageToSend,
+    ) -> Result<()> {
+        let num_consumers = consumers.len();
+        if num_consumers == 0 {
+            return Err(anyhow!("No consumers available to dispatch the message"));
         }
-    }
-
-    async fn find_next_active_consumer(&self) -> Result<Consumer> {
-        let num_consumers = self.consumers.len();
 
         for _ in 0..num_consumers {
-            let consumer = self.get_next_consumer()?;
-            if !consumer.get_status().await {
-                continue;
+            let index = index_consumer.fetch_add(1, Ordering::SeqCst) % num_consumers;
+            let consumer = &mut consumers[index];
+
+            if consumer.get_status().await {
+                consumer.send_message(message).await?;
+                trace!(
+                    "Dispatcher sent the message to consumer: {}",
+                    consumer.consumer_id
+                );
+                return Ok(());
             }
-
-            return Ok(consumer);
         }
 
-        return Err(anyhow!("unable to find an active consumer"));
-    }
-
-    pub(crate) fn get_next_consumer(&self) -> Result<Consumer> {
-        let num_consumers = self.consumers.len();
-
-        if num_consumers == 0 {
-            return Err(anyhow!("There are no consumers left"));
-        }
-
-        // Use modulo to ensure index wraps around
-        let index = self
-            .index_consumer
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
-            % num_consumers;
-
-        // Get the consumer at the computed index
-        self.consumers
-            .get(index)
-            .cloned() // Clone the Arc<Mutex<Consumer>> to return
-            .ok_or_else(|| anyhow!("Unable to find the next consumer"))
-    }
-
-    pub(crate) async fn disconnect_all_consumers(&mut self) -> Result<Vec<u64>> {
-        let mut consumers = Vec::new();
-
-        for consumer in self.consumers.iter() {
-            consumers.push(consumer.consumer_id)
-        }
-
-        for consumer_id in consumers.iter() {
-            self.remove_consumer(consumer_id.clone()).await?;
-        }
-
-        Ok(consumers)
-    }
-
-    // manage the removal of consumers from the dispatcher
-    pub(crate) async fn remove_consumer(&mut self, consumer_id: u64) -> Result<()> {
-        // Find the position asynchronously
-        let pos = {
-            let mut pos = None;
-            for (index, x) in self.consumers.iter().enumerate() {
-                if x.consumer_id == consumer_id {
-                    pos = Some(index);
-                    break;
-                }
-            }
-            pos
-        };
-
-        // If a position was found, remove the consumer at that position
-        if let Some(pos) = pos {
-            self.consumers.remove(pos);
-        }
-
-        Ok(())
+        Err(anyhow!(
+            "No active consumers available to handle the message"
+        ))
     }
 }

--- a/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
+++ b/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
@@ -68,7 +68,6 @@ impl DispatcherMultipleConsumers {
 
         for _ in 0..num_consumers {
             let consumer = self.get_next_consumer()?;
-
             if !consumer.get_status().await {
                 continue;
             }

--- a/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
+++ b/danube-broker/src/dispatcher/dispatcher_multiple_consumers.rs
@@ -1,20 +1,22 @@
 use anyhow::{anyhow, Result};
-use std::sync::atomic::AtomicUsize;
+use std::sync::{atomic::AtomicUsize, mpsc::Receiver};
 use tracing::trace;
 
-use crate::{consumer::MessageToSend, subscription::ConsumerInfo};
+use crate::{consumer::MessageToSend, dispatcher::DispatcherCommand, subscription::ConsumerInfo};
 
 #[derive(Debug)]
 pub(crate) struct DispatcherMultipleConsumers {
-    consumers: Vec<ConsumerInfo>,
+    consumers: Vec<Consumer>,
     index_consumer: AtomicUsize,
+    rx_disp: Receiver<DispatcherCommand>,
 }
 
 impl DispatcherMultipleConsumers {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(rx_disp: Receiver<DispatcherCommand>) -> Self {
         DispatcherMultipleConsumers {
             consumers: Vec::new(),
             index_consumer: AtomicUsize::new(0),
+            rx_disp,
         }
     }
 

--- a/danube-broker/src/dispatcher/dispatcher_single_consumer.rs
+++ b/danube-broker/src/dispatcher/dispatcher_single_consumer.rs
@@ -54,7 +54,6 @@ impl DispatcherSingleConsumer {
         // 3. other permits like dispatch rate limiter, quota etc
 
         let consumer_status = active_consumer.status.lock().await;
-
         // check if the consumer is active
         if !consumer_status.to_owned() {
             // Pick a new active consumer
@@ -73,9 +72,6 @@ impl DispatcherSingleConsumer {
 
     // manage the addition of consumers to the dispatcher
     pub(crate) async fn add_consumer(&mut self, consumer: Consumer) -> Result<()> {
-        // Handle Exclusive Subscription
-        // The consumer addition is not allowed if there are consumers in the list and Subscription is Exclusive
-
         // if the subscription is Shared should not be routed to this dispatcher
         if consumer.subscription_type == 1 {
             return Err(anyhow!(
@@ -83,6 +79,8 @@ impl DispatcherSingleConsumer {
             ));
         }
 
+        // Handle Exclusive Subscription
+        // The consumer addition is not allowed if there are consumers in the list and Subscription is Exclusive
         if consumer.subscription_type == 0 && !self.consumers.is_empty() {
             // connect to active consumer self.active_consumer
             warn!("Not allowed to add the Consumer: {}, the Exclusive subscription can't be shared with other consumers", consumer.consumer_id);

--- a/danube-broker/src/subscription.rs
+++ b/danube-broker/src/subscription.rs
@@ -1,10 +1,12 @@
 use anyhow::{anyhow, Ok, Result};
+use metrics::gauge;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{mpsc, Mutex};
 use tracing::trace;
 
 use crate::{
+    broker_metrics::TOPIC_CONSUMERS,
     consumer::{Consumer, MessageToSend},
     dispatcher::{
         dispatcher_multiple_consumers::DispatcherMultipleConsumers,
@@ -21,8 +23,6 @@ pub(crate) struct Subscription {
     pub(crate) subscription_type: i32,
     pub(crate) topic_name: String,
     pub(crate) dispatcher: Option<Dispatcher>,
-    pub(crate) tx_disp: Option<mpsc::Sender<MessageToSend>>,
-    pub(crate) rx_disp: Option<Arc<Mutex<mpsc::Receiver<MessageToSend>>>>,
     pub(crate) consumers: HashMap<u64, ConsumerInfo>,
 }
 
@@ -38,9 +38,9 @@ impl ConsumerInfo {
     pub(crate) async fn get_status(&self) -> bool {
         *self.status.lock().await
     }
-    // pub(crate) async fn set_status_false(&self) -> () {
-    //     *self.status.lock().await = false
-    // }
+    pub(crate) async fn set_status_false(&self) -> () {
+        *self.status.lock().await = false
+    }
     pub(crate) async fn set_status_true(&self) -> () {
         *self.status.lock().await = true
     }
@@ -66,8 +66,6 @@ impl Subscription {
             subscription_type: sub_options.subscription_type,
             topic_name: topic_name.into(),
             dispatcher: None,
-            tx_disp: None,
-            rx_disp: None,
             consumers: HashMap::new(),
         }
     }
@@ -94,19 +92,8 @@ impl Subscription {
         // checks if there'a a dispatcher (responsible for distributing messages to consumers)
         // if not initialize a new dispatcher based on the subscription type: Exclusive, Shared, Failover
         if self.dispatcher.is_none() {
-            //for communication with the dispatcher
-            let (tx_disp, rx_disp) = mpsc::channel(4);
-            let shared_rx = Arc::new(Mutex::new(rx_disp));
-            let rx_clone = Arc::clone(&shared_rx);
+            let new_dispatcher = self.create_new_dispatcher(options.clone())?;
 
-            let mut new_dispatcher = self.create_new_dispatcher(options.clone(), rx_clone)?;
-
-            // Start the dispatcher here
-            if let Err(error) = new_dispatcher.run().await {
-                return Err(anyhow!("Failed to start dispatcher: {}", error));
-            };
-
-            self.tx_disp = Some(tx_disp);
             self.dispatcher = Some(new_dispatcher);
         };
 
@@ -133,20 +120,16 @@ impl Subscription {
         Ok(consumer_id)
     }
 
-    pub(crate) fn create_new_dispatcher(
-        &self,
-        options: SubscriptionOptions,
-        rx_disp: Arc<Mutex<mpsc::Receiver<MessageToSend>>>,
-    ) -> Result<Dispatcher> {
+    pub(crate) fn create_new_dispatcher(&self, options: SubscriptionOptions) -> Result<Dispatcher> {
         let new_dispatcher = match options.subscription_type {
             // Exclusive
-            0 => Dispatcher::OneConsumer(DispatcherSingleConsumer::new(rx_disp)),
+            0 => Dispatcher::OneConsumer(DispatcherSingleConsumer::new()),
 
             // Shared
-            1 => Dispatcher::MultipleConsumers(DispatcherMultipleConsumers::new(rx_disp)),
+            1 => Dispatcher::MultipleConsumers(DispatcherMultipleConsumers::new()),
 
             // Failover
-            2 => Dispatcher::OneConsumer(DispatcherSingleConsumer::new(rx_disp)),
+            2 => Dispatcher::OneConsumer(DispatcherSingleConsumer::new()),
 
             _ => {
                 return Err(anyhow!("Should not get here"));
@@ -158,18 +141,8 @@ impl Subscription {
 
     pub(crate) async fn send_message_to_dispatcher(&self, message: MessageToSend) -> Result<()> {
         // Try to send the message
-        if let Some(tx_disp) = &self.tx_disp {
-            if tx_disp.try_send(message.clone()).is_err() {
-                // Buffer is full; drop the oldest message
-                let mut rx = self.rx_disp.as_ref().unwrap().lock().await;
-                let _ = rx.try_recv();
-
-                //try again
-                if tx_disp.try_send(message).is_err() {
-                    //this is something wrong with the dispatcher
-                    return Err(anyhow!("Failed to send message to dispatcher"));
-                }
-            }
+        if let Some(dispatcher) = self.dispatcher.as_ref() {
+            dispatcher.dispatch_message(message).await?;
         } else {
             return Err(anyhow!("Dispatcher not initialized"));
         }
@@ -193,13 +166,28 @@ impl Subscription {
         None
     }
 
+    // Get Consumers
+    pub(crate) fn get_consumers_info(&self) -> Vec<ConsumerInfo> {
+        let consumers = self.consumers.values().cloned().collect::<Vec<_>>();
+        consumers
+    }
+
     // handles the disconnection of consumers associated with the subscription.
     pub(crate) async fn disconnect(&mut self) -> Result<Vec<u64>> {
         let mut consumers_id = Vec::new();
 
+        for (consumer_id, consumer_info) in self.consumers.iter_mut() {
+            if consumer_info.get_status().await {
+                // if consumer exist and its status is true, then set the status to false
+                consumer_info.set_status_false().await;
+                consumers_id.push(*consumer_id);
+            }
+            gauge!(TOPIC_CONSUMERS.name, "topic" => self.topic_name.to_string()).decrement(1);
+        }
+
+        // Disconnect all consumers
         if let Some(dispatcher) = self.dispatcher.as_mut() {
-            let mut disconnected_consumers = dispatcher.disconnect_all_consumers().await?;
-            consumers_id.append(&mut disconnected_consumers);
+            dispatcher.disconnect_all_consumers().await?;
         }
 
         Ok(consumers_id)
@@ -221,24 +209,10 @@ impl Subscription {
         None
     }
 
-    // Get Consumers
-    pub(crate) fn get_consumers(&self) -> Vec<u64> {
-        self.consumers.keys().cloned().collect()
-    }
-
     pub(crate) fn is_exclusive(&self) -> bool {
         if self.subscription_type == 0 {
             return true;
         }
         return false;
-    }
-
-    // Get Dispatcher
-    pub(crate) fn get_dispatcher(&self) -> Option<&Dispatcher> {
-        // maybe create  a trait that the both dispatachers will implement
-        if let Some(dispatcher) = &self.dispatcher {
-            return Some(dispatcher);
-        }
-        None
     }
 }

--- a/danube-broker/src/subscription.rs
+++ b/danube-broker/src/subscription.rs
@@ -103,7 +103,11 @@ impl Subscription {
             let shared_rx = Arc::new(Mutex::new(rx_disp));
             let rx_clone = Arc::clone(&shared_rx);
 
-            let dispatcher = self.create_new_dispatcher(options.clone(), rx_clone)?;
+            let mut dispatcher = self.create_new_dispatcher(options.clone(), rx_clone)?;
+
+            // Start the dispatcher here
+            dispatcher.run().await;
+
             self.dispatcher = Some(dispatcher);
             self.tx_disp = Some(tx_disp);
             self.dispatcher.as_mut().unwrap()
@@ -150,10 +154,6 @@ impl Subscription {
                 return Err(anyhow!("Should not get here"));
             }
         };
-
-        let _dispatcher_handle = tokio::spawn(async move {
-            new_dispatcher.run().await;
-        });
 
         Ok(new_dispatcher)
     }

--- a/danube-broker/src/topic.rs
+++ b/danube-broker/src/topic.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use metrics::counter;
 use std::collections::{hash_map::Entry, HashMap};
 use tokio::sync::Mutex;
-use tracing::{info, trace, warn};
+use tracing::{info, warn};
 
 use crate::proto::MessageMetadata;
 use crate::{
@@ -141,19 +141,15 @@ impl Topic {
 
             for (_name, subscription) in subscriptions.iter() {
                 let duplicate_message = message_to_send.clone();
-                if let Some(dispatcher) = subscription.get_dispatcher() {
-                    if let Err(err) = dispatcher.send_messages(duplicate_message).await {
-                        info!(
-                            "The subscription {}, has no active consumers, got error: {} ",
-                            subscription.subscription_name, err
-                        );
-                        to_remove.push(subscription.subscription_name.clone());
-                    }
-                } else {
-                    trace!(
-                        "No dispatcher has been found for subscription {}",
-                        subscription.subscription_name
+                if let Err(err) = subscription
+                    .send_message_to_dispatcher(duplicate_message)
+                    .await
+                {
+                    info!(
+                        "The subscription {}, has no active consumers, got error: {} ",
+                        subscription.subscription_name, err
                     );
+                    to_remove.push(subscription.subscription_name.clone());
                 }
             }
 

--- a/danube-broker/src/topic.rs
+++ b/danube-broker/src/topic.rs
@@ -194,7 +194,7 @@ impl Topic {
                 sub_metadata,
             ));
 
-        if subscription.is_exclusive() && !subscription.get_consumers().is_empty() {
+        if subscription.is_exclusive() && !subscription.get_consumers_info().is_empty() {
             warn!("Not allowed to add the Consumer: {}, the Exclusive subscription can't be shared with other consumers", options.consumer_name);
             return Err(anyhow!("Not allowed to add the Consumer: {}, the Exclusive subscription can't be shared with other consumers", options.consumer_name));
         }
@@ -236,8 +236,7 @@ impl Topic {
         let sub_guard = self.subscriptions.lock().await;
         let subs = sub_guard.get(subscription)?;
 
-        let disp = subs.get_dispatcher()?;
-        let consumers = disp.get_consumers();
+        let consumers = subs.get_consumers_info();
 
         for consumer_info in consumers {
             if consumer_info.get_status().await {

--- a/danube-client/src/producer.rs
+++ b/danube-client/src/producer.rs
@@ -239,14 +239,13 @@ impl ProducerBuilder {
     ///
     /// # Example
     ///
-    /// ```rust
     /// let producer = ProducerBuilder::new()
     ///     .with_topic("my-topic")
     ///     .with_name("my-producer")
     ///     .with_partitions(3)
     ///     .with_schema("my-schema".to_string(), SchemaType::Json("schema-definition".to_string()))
     ///     .build()?;
-    /// ```
+    ///
     pub fn build(self) -> Producer {
         let topic_name = self
             .topic


### PR DESCRIPTION
improve performance by running the dispatcher in a separate task, therefore decoupling the consumer by the main program.